### PR TITLE
Run Your Code Generator as a Test

### DIFF
--- a/.project-words.txt
+++ b/.project-words.txt
@@ -32,6 +32,7 @@ commercialise
 containerising
 cplusplus
 Culting
+customisation
 customise
 dakom
 danielhenrymantilla
@@ -83,6 +84,7 @@ lpass
 Makefiles
 malloc
 markedit
+Matklad
 matthieum
 mdbook
 memcpy
@@ -95,8 +97,10 @@ mish
 Modularly
 Multiversal
 navmesh
+normalisation
 Nomicon
 Nystrom
+ogen
 optimise
 Optimise
 orbtk
@@ -137,12 +141,14 @@ setpoint
 sharedfolderid
 smol
 solidworks
+sqlc
 specialise
 spkr
 Spolsky
 stabilised
 staticlib
 stdint
+stringly
 structopt
 synchronisation
 texel

--- a/content/posts/accidental-application-runtime.md
+++ b/content/posts/accidental-application-runtime.md
@@ -10,7 +10,7 @@ tags:
 
 Imagine you look after the software for a small 3D-print farm: a rack of printers and a Go service running on a box in the corner. The service started life as a dashboard. Somebody wanted to see what each printer was doing without walking over to it, so you wrote a little HTTP server, and because the handlers needed live printer state, the server's setup code connected to the printers and started a goroutine to poll them. That was completely reasonable.
 
-Then the central backend came along. Jobs now arrive from upstream, so the service grew a goroutine that pulls them down into a SQLite-backed job store. Something has to match queued jobs to idle printers, so it grew a scheduler. Something has to actually send G-code to a printer and watch it happen, so it grew a runner. Each of these landed in the same setup path, because that's where the printer connections and the store already lived, and each was a small, sensible change that took an afternoon.
+Then the central backend came along and jobs started arriving from upstream. The service grew a goroutine that pulled them into a SQLite-backed job store. Once they were there, it also needed to match queued jobs to idle printers, send G-code, and watch the print. Those pieces all landed in the same setup path because that's where the printer connections and store already lived. Each change was small enough to do in an afternoon.
 
 A while later the backend team asked for periodic status reports, and by then nobody even paused before adding another goroutine to the pile. The setup code now looks something like this:
 
@@ -43,7 +43,7 @@ func NewServer(cfg Config) (*Server, error) {
 }
 ```
 
-This code isn't obviously bad. Each line was a reasonable next step, and the application does print things. The trouble is that the setup code now owns all of the application's long-running work.
+There isn't an obviously bad line here. Each one was a reasonable next step, and the application does print things. It's only when you look at the whole function that the problem becomes apparent: the setup code owns all of the application's long-running work.
 
 ## Then Someone Asks for Graceful Shutdown
 
@@ -51,15 +51,15 @@ The problem showed up when somebody asked for graceful shutdown. Deploying a new
 
 You sit down to thread cancellation through the code, and the questions start piling up. Which goroutines are even running? The only way to answer is to read the setup code and everything it calls. What order should they stop in? The scheduler feeds the runner through a channel. If the scheduler exits first, who closes it, and is the runner allowed to finish draining it? The puller and the reporter both talk to the backend; do they share a shutdown deadline? Every background failure so far has just been logged and forgotten, and now some of them are supposed to trigger an orderly teardown instead. All of these answers have to be expressed *inside an HTTP server object*, because that's the thing that owns everything.
 
-None of these questions is hard on its own. You stop and ask whether there's a better way because the code gives you nowhere to answer them. The lifetimes you're being asked to coordinate are implicit in five `go` statements and the order of some struct fields.
+None of these questions is especially hard on its own. This is usually where I stop treating it as a shutdown problem, because the code gives me nowhere sensible to put the answers. The lifetimes are implicit in five `go` statements and the order of some struct fields.
 
 ## An Accidental Runtime
 
-Every application with more than one long-lived activity has a runtime in the small, whether or not anyone designed it: something decides what those activities are, what they're allowed to touch, how they hear about each other, and when they stop. We normally reserve the word "runtime" for the machinery underneath the language, but your application has one of its own. In the print-farm service, that setup code lives in `NewServer`. This wasn't a deliberate choice. The HTTP server was simply the first object that needed the shared state, so it became the place where long-running things get born, and every later addition reinforced the pattern. That's what I mean by an *accidental* application runtime.
+I find it useful to think of any application with several long-lived activities as having a small runtime of its own. Something still decides what those activities are, what they're allowed to touch, how they hear about each other, and when they stop, even if nobody designed that part explicitly. In the print-farm service, the runtime happens to live in `NewServer`. The HTTP server was simply the first object that needed the shared state, so it became the place where long-running things get born. Later additions followed the existing pattern. That's what I mean by an *accidental* application runtime.
 
 Calling this "large setup code" misses what has changed. The service now has five concurrent components with fairly clear responsibilities and well-defined data flowing between them. You could sketch them on a whiteboard in a minute, once you'd worked them out, but no artefact in the codebase expresses that design. It exists only in the side effects of wiring code: a field here, a `go` statement there, a channel threaded through two private methods. "A web server with some helpers" stopped being a true description a long time ago. The application has developed a larger architecture without representing it as one.
 
-Graceful shutdown happened to be the request that exposed this for me. For you it might be a component you can't test without standing up the whole process, a new feature with no obvious home, or a new team member asking "what talks to what?" and watching you open six files to answer. These are all signs that the application's working architecture is only visible indirectly.
+Graceful shutdown happened to be the request that exposed this for me. Sometimes it shows up as a component you can't test without standing up the whole process, or a new feature with no obvious home. A new team member asking "what talks to what?" while you open six files is another good clue. The application's working architecture is only visible indirectly.
 
 HTTP is only one place this happens. The same accretion happens to a CLI command's run function, the setup code around a message-queue consumer, a GUI main window, or a `main()` that grew organically. Wherever starting the application revolves around one convenient object, that object gradually becomes the runtime. HTTP servers are unusually good hosts for the pattern because they're long-lived, they're created early, and every feature eventually wants to show something to a user.
 
@@ -69,7 +69,7 @@ This design grew out of a real Go edge service that talks to hardware, whose det
 
 Once I'd named the problem, I wanted prior art for making this kind of architecture explicit. The codebase that taught me the most wasn't a web framework. It was [PX4][px4], the open-source drone autopilot. I've spent a fair amount of time in its source and documentation. It makes our print farm look leisurely, with sensor drivers producing data at hundreds of hertz, estimators fusing it, controllers consuming the estimates, telemetry, logging, and dozens of other concurrent activities running on a flight controller.
 
-Three ideas from [PX4's architecture][px4-arch] transfer almost directly.
+I kept coming back to three things in [PX4's architecture][px4-arch].
 
 **Modules within one process.** PX4 is built as self-contained modules that communicate through asynchronous message passing, but it is not a distributed system: the modules share an address space and run as tasks or on shared work queues. It provided the strong internal boundaries I was missing without requiring separate services.
 
@@ -77,13 +77,11 @@ Three ideas from [PX4's architecture][px4-arch] transfer almost directly.
 
 **Topology you can generate.** Because modules declare their subscriptions and publications in code, PX4 can extract a [graph of modules and topics][uorb-graph] straight from the source. The architecture diagram isn't a wiki page that rots; it's derived from the same declarations that run the system.
 
-I want to give proper credit here because the shape of everything that follows is borrowed from PX4. I've chosen different delivery guarantees, though. uORB is tuned for control loops: a topic's default queue holds a single message, and newer publications overwrite any unread value. That works when only the freshest gyro sample matters. A completion event such as "a job finished" needs different treatment. The design below defaults to backpressured delivery, treats latest-value delivery as an explicit concept, and makes no attempt to reproduce uORB's implementation, multi-instance topics, or lifecycle for starting and stopping individual modules.
+I want to give proper credit here because the shape of everything that follows is borrowed from PX4. This is also where I stopped copying it. uORB is tuned for control loops: a topic's default queue holds a single message, and newer publications overwrite any unread value. That works when only the freshest gyro sample matters, but a completion event such as "a job finished" needs different treatment. The design below uses backpressure by default and treats latest-value delivery separately. It doesn't try to reproduce uORB's implementation, multi-instance topics, or lifecycle for starting and stopping individual modules.
 
 ## Modules as Ordinary Functions
 
-So: what's the smallest way to say "this application is a set of concurrent modules that exchange typed messages and share a few resources" in Go, without inventing a schema language, a registration DSL, or a framework the reader has to learn?
-
-My answer, after some false starts, is that you already say it every time you write a function signature:
+I wanted the smallest way to say "this application is a set of concurrent modules that exchange typed messages and share a few resources" in Go, without inventing a schema language, a registration DSL, or a framework the reader has to learn. After some false starts, I ended up using ordinary function signatures:
 
 ```go
 func MonitorPrinters(
@@ -118,13 +116,11 @@ err = app.Run(ctx, printers, store)
 
 `New` *records* the module signatures; it never calls a module. Keeping declaration separate from execution means the same signatures can produce an architecture diagram without opening a database connection, while `Run` can validate the entire wiring before a single module starts. Registering a function is simultaneously writing executable code and writing down where that code sits in the design.
 
-Two contracts matter here because the accidental version blurred both of them.
+The accidental version blurred messages and resources. `PrinterState` is a flow of values; the job store is a capability. Both used to sit on one struct beside the subscriptions, where everything could touch everything else. Here, streams are channel parameters and resources are everything else, and the runtime wires them differently.
 
-First, **messages versus resources**. `PrinterState` is a flow of values; the job store is a capability. The accidental runtime put the state cache, store, and subscriptions on one struct, where everything could touch everything else. Here, a stream is a channel parameter and a resource is any other parameter, and the two are wired differently.
+That doesn't mean every interaction becomes a message. When an HTTP handler needs to pause a job *and tell the user whether that worked*, a direct method call on the store is the honest contract. The module just declares the store as a resource.
 
-Second, **messages versus calls**. Nothing forces request/response work through the bus. When an HTTP handler needs to pause a job *and tell the user whether that worked*, a direct method call on the store is the honest contract, and the module simply declares the store as a resource.
-
-The uniform `ctx`-and-`error` shape also makes lifecycle and failure part of the contract. Every module must accept a context, so module authors deal with cancellation from the start instead of retrofitting it later. Every module must also return an `error`, which gives failures somewhere legitimate to go besides a log line inside a forgotten goroutine.
+The common `ctx`-and-`error` shape deals with another bit of the original mess. Module authors have to consider cancellation when they write the function, and failures have somewhere legitimate to go besides a log line inside a forgotten goroutine.
 
 Here's the rough shape we're heading towards, using a slice of the print farm. Modules are boxes, typed topics label the arrows, and resources use dashed lines:
 
@@ -192,7 +188,7 @@ Around this sits `inspectModule`, which requires a non-nil, non-variadic functio
 
 ## Running the Modules
 
-`Run(ctx, resources...)` has two jobs: bind the caller's resources to the declared parameters, and supervise the modules.
+`Run(ctx, resources...)` binds the caller's resources to the declared parameters, then supervises the modules.
 
 Resource binding stays simple. The caller passes already-created values, with no providers or factories. Each resource parameter binds to exactly one value: first by exact type, then by *unique* assignability, so a concrete `*SQLiteJobStore` can satisfy a `JobStore` interface without ceremony. Nil values, duplicate types, ambiguous matches, missing resources, and unused resources are all rejected before any module starts. Rejecting an unused resource occasionally annoys me for about ten seconds. Then I remember it's almost always a wiring mistake I'd rather hear about now.
 
@@ -328,11 +324,11 @@ This is a fan-out loop with a handful of `select` cases. What matters is having 
 
 ## Rebuilding the Print Farm
 
-Rebuilding the service tests the design against something messier than a pipeline.
+The print farm is where the design has to survive something messier than a pipeline.
 
-Deciding the module boundaries is mostly deciding who owns what. The central backend owns job creation, queue membership, and priority. Arguing with it locally would mean building conflict resolution I don't want to teach or maintain. The local HTTP interface owns the immediate physical controls: pause, cancel, take a printer out of service. SQLite, behind an opaque `JobStore` interface, owns everything that must survive a restart: queued jobs, claimed assignments, and terminal outcomes. The bus handles live, in-process coordination.
+I ended up choosing the module boundaries by asking who already owned each decision. The central backend owns job creation, queue membership, and priority. Arguing with it locally would mean building conflict resolution I don't want to teach or maintain. The local HTTP interface owns immediate physical controls such as pause, cancel, and taking a printer out of service. SQLite, behind an opaque `JobStore` interface, keeps everything that must survive a restart: queued jobs, claimed assignments, and terminal outcomes. The bus is left with live, in-process coordination.
 
-That split produces six modules:
+The version I ended up with has six modules:
 
 ```go
 // Watches the printers, publishing a snapshot whenever one changes.
@@ -370,7 +366,7 @@ func BuildFarmState(ctx context.Context, printers <-chan PrinterState,
 	farm chan<- FarmState) error
 ```
 
-`ServeHTTP` is now one peer among six. It has real dependencies and can pause a job through the store, but it no longer starts the rest of the application. `BuildFarmState` consumes three topics and publishes a derived one without doing any I/O. The accidental runtime had this logic as a cache bolted onto the server; now it's a component you can read, replace, or test on its own.
+`ServeHTTP` is now one peer among six. It can still pause a job through the store, but it no longer starts the rest of the application. `BuildFarmState` consumes three topics and publishes a derived one without doing any I/O. That logic used to be a cache bolted onto the server. Pulling it out also made it something I could test on its own.
 
 The subtlest contract in the system is between the store and the bus. `QueueChanged` and `AssignmentReady` are notifications about durable state, never the state itself. Any durable mutation follows commit-then-notify: `ScheduleJobs` claims a job in SQLite first, then announces `AssignmentReady` to wake the runner. If the process dies between those steps, the claim remains in the store. After restart, the scheduler and runner reconcile against the store because a notification from the previous process is gone forever. SQLite remains the durable record; bus messages merely wake modules up.
 
@@ -428,7 +424,7 @@ Rebuilding the print farm exposes one more contract. `FarmState` is the aggregat
 
 A declared subscriber is the wrong contract for either. Backpressured delivery lets every subscriber slow the publisher down. That behaviour is useful between the runner and scheduler, but somebody's phone on hotel Wi-Fi shouldn't be able to stall the runner. The periodic reporter asks "what's the farm state right now?" twice a minute and ignores everything else. The SSE endpoint can miss intermediate progress events, but one `JobProgress` value is not the current state of every active job. A new client fetches the aggregate `FarmState` first, then watches progress events.
 
-A subscriber receives every value and applies backpressure. The HTTP and reporting modules need a cheap view of the latest value instead. Blurring those contracts is how streaming endpoints grow bespoke buffers, drop policies, and replay caches one incident at a time, so the latter gets its own type: `*backplane.Latest[T]`. Declaring one gives the module a live view of a topic. `Load` returns the most recent value and when it arrived, while `Watch` serves the streaming case:
+A subscriber receives every value and applies backpressure. The HTTP and reporting modules only need a cheap view of the latest value. I gave that a separate type, `*backplane.Latest[T]`, rather than letting each streaming endpoint grow its own buffer and drop policy. Declaring one gives the module a live view of a topic. `Load` returns the most recent value and when it arrived, while `Watch` serves the streaming case:
 
 ```go
 // Watch returns a channel that converges on the most recent value: the
@@ -467,7 +463,7 @@ for watcher := range l.watchers {
 }
 ```
 
-With `Latest`, the SSE handler collapses into something you'd be happy to review: send the current `FarmState`, watch the progress projection, send each newer event as it arrives, and let the channel closing end the loop. The aggregate snapshot remains the source of current per-job state; `Latest[JobProgress]` is only the most recent incremental event. The runtime already knew both; it just needed contracts that kept a slow browser out of the publishers' way.
+With `Latest`, the SSE handler sends the current `FarmState`, watches the progress projection, and lets the channel closing end the loop. The aggregate snapshot remains the source of current per-job state; `Latest[JobProgress]` is only the most recent incremental event. More importantly, a slow browser stays out of the publishers' way.
 
 ## Testing the Pieces
 
@@ -590,7 +586,7 @@ flowchart TB
   n5 --> n12
 ```
 
-This is the whiteboard sketch from back when we were diagnosing the problem, generated from the same signatures that `Run` executes. Nobody needs to maintain it separately, and regenerating it after a refactor takes one command.
+This is roughly the whiteboard sketch from back when I was diagnosing the problem, except it came from the same signatures that `Run` executes. After a refactor, I can regenerate it instead of trying to remember which arrows changed.
 
 The generated graph is candid about a few things that hand-drawn diagrams tend to omit. `JobFinished` loops back into `ScheduleJobs`, and `ServeHTTP` sits on the edge as one consumer among several. The cylindrical `JobStore` node records that synchronous operator commands still use method calls. Four modules touch the store, which is real coupling I've deliberately retained. The graph exposes it instead of tidying it away. It describes declared topology, so it cannot report whether a module is healthy or publishing. It also cannot see communication through resource methods, globals, callbacks, or private workers. Even with those limits, it is enough to explain the system to someone new or argue about where a proposed feature should live.
 
@@ -620,11 +616,9 @@ This gives a monolith some properties I value in microservices: clear ownership,
 
 ## Recognising It Next Time
 
-The diagnosis applies beyond this particular implementation, and it's the part I'd like you to take away.
+The bit I now watch for is setup code — perhaps a run function or consumer loop — that starts several goroutines because it already has access to their dependencies. The application may have outgrown its original structure even though the architecture is still only visible in the wiring.
 
-The pattern to watch for is setup code — perhaps a run function or consumer loop — that starts several goroutines simply because it already has access to their dependencies. The application may have outgrown its original structure even though its architecture is still only visible in the wiring. Before reaching for a service boundary or framework, ask: *what are the long-running parts of this application, what flows between them, and where is any of that written down?*
-
-If the answer is "nowhere", that doesn't mean the code is bad. It means a design has probably emerged without being written down. A bus like this one is one way to make it explicit. The particular mechanism matters less than giving that architecture a place in the code.
+I wouldn't jump straight from there to a service boundary or a runtime library. First, I write down the long-running parts and what flows between them. If that explanation has no obvious home in the code, a design has probably emerged without being represented yet. A bus like this one is one option. The useful part is giving the architecture somewhere to live.
 
 [px4]: https://px4.io/
 [px4-arch]: https://docs.px4.io/main/en/concept/architecture

--- a/content/posts/run-your-code-generator-as-a-test.md
+++ b/content/posts/run-your-code-generator-as-a-test.md
@@ -14,9 +14,9 @@ At some point in a project's life, somebody runs a code generator. Maybe they po
 
 That sentence is where the trouble starts. The project now contains two representations of the same information, an authoritative one and a derived one, and the only thing keeping them consistent is a human remembering to run a command.
 
-I've used a pattern for years that removes the remembering: run the generator from the test suite, compare its output against what's checked in, repair any difference, and fail the test so the change still gets reviewed. It's a small amount of code, it works with any deterministic generator, and once it's in place the derived code simply can't drift without CI telling you about it. This article walks through the two helpers that make it work, a complete worked example that generates a Go client from a running web application, and the costs you accept by adopting it.
+I've used a pattern for years: run the generator from the test suite, compare its output against what's checked in, repair any difference, and fail the test so the change still gets reviewed. It's a small amount of code and works with any deterministic generator. CI then has a way to report drift instead of relying on a README instruction.
 
-## The Command Somebody Has to Remember
+## How Generated Code Drifts
 
 A one-off generation is fine on the day it happens. The generated code matches its source because both were touched in the same sitting, and everybody involved still remembers how the pieces fit together. The problem is that projects evolve, and the moment either side can change, the derivation can rot in two different directions.
 
@@ -24,7 +24,7 @@ The first direction is the obvious one: the authoritative input changes and nobo
 
 The second direction is sneakier. Somebody needs a small change, notices it would be quickest to make it in the generated file, and patches it directly. The patch works, it gets committed, and it quietly becomes load-bearing. Months later somebody else re-runs the generator for an unrelated reason and the patch evaporates, usually without anyone noticing until whatever depended on it breaks.
 
-Both failures have the same root cause. Re-running the generator is a task that is almost always redundant; 99% of the time the output wouldn't change, so there's no feedback loop teaching anyone to do it. Humans are bad at remembering rarely-needed chores, and a README can document the command but can't make anyone run it. If keeping two representations consistent matters, the check needs to be executable, and the natural place for an executable check is the test suite. CI already runs it, and every developer already knows what a red test means.
+Both failures have the same root cause. Re-running the generator is almost always redundant; 99% of the time the output wouldn't change, so there's no feedback loop teaching anyone to do it. Humans are bad at remembering rarely-needed chores. A README can document the command, but the test suite can run it in CI and give developers a familiar red test when the representations diverge.
 
 ## Run the Generator From a Test
 
@@ -72,9 +72,7 @@ func TestLookupTableIsUpToDate(t *testing.T) {
 }
 ```
 
-The behaviour on drift looks strange the first time you see it: the helper *fixes* the file and then fails anyway. Why not just fix it and pass, or fail without touching anything?
-
-Because each half of that behaviour serves a different audience. Writing the file means a developer who runs the test locally is left with the correct output sitting in their working tree, as a concrete diff they can read in their usual tools, rather than a wall of "expected X, got Y" output and a chore still ahead of them. Failing the test means CI can never go green on a commit whose generated code didn't match its source, because CI's rewritten file is thrown away with the build machine. The failure message tells the developer exactly what happened and what to do next: inspect the diff, commit it, rerun. On the second run the file already matches and the test passes. Every regeneration therefore passes through a human and through code review, exactly like a handwritten change would.
+The behaviour on drift looks strange the first time you see it: the helper *fixes* the file and then fails anyway. Writing the file leaves a developer running the test locally with a concrete diff to inspect, rather than a wall of expected-versus-actual output and another command to run. Failing the test keeps CI red, because any rewrite made on the build machine disappears with it. The next run sees matching contents and passes.
 
 ### `AssertFileTreeMatches()`
 
@@ -189,13 +187,13 @@ func pruneEmptyDirs(dir string) {
 
 {{% /expand %}}
 
-The deletion pass is what makes this helper genuinely different from calling `EnsureFileContents()` in a loop, and it's also where the sharpest edge lives. Because stale files get removed, the target directory has to be *wholly owned* by the generator. A handwritten file dropped into that directory will survive exactly until the next test run. That's a boundary worth establishing deliberately: generated output goes in its own directory, handwritten code lives elsewhere, and the directory's ownership is obvious from its name or a README inside it.
+The deletion pass distinguishes this helper from calling `EnsureFileContents()` in a loop. Because stale files get removed, the target directory has to be *wholly owned* by the generator. A handwritten file dropped into that directory will survive until the next test run. Put generated output in its own directory, with the ownership clear from its name or a README.
 
-With both helpers in hand, the overall contract is worth spelling out once. The authoritative input (the schema, the migrations, the grammar) remains the only place where intentional changes happen. The test regenerates the derived code exactly and compares it byte-for-byte, which catches both drift directions from earlier: stale output when the source changed, and manual edits to the output itself. And because the output is checked in rather than produced at build time, everyone downstream still gets the good parts of committed code: jump-to-definition, autocomplete, docs rendered from the source, diffs that show up in review, and no requirement that every consumer has the generator toolchain installed.
+Together, the helpers establish the contract. The authoritative input (the schema, the migrations, the grammar) is where intentional changes happen. The test regenerates the derived code and compares it byte-for-byte, so changes to either side show up as a failing test. Checked-in output still gives downstream users jump-to-definition, autocomplete, rendered documentation, reviewable diffs, and no requirement to install the generator toolchain.
 
-## Generate a Client From a Running API
+## A Real OpenAPI Client
 
-To show the whole pattern working end to end, I want a generator that somebody would actually use, against a source of truth that actually changes. Generating an API client from a real application's OpenAPI document fits both requirements, so the worked example uses [Mealie][mealie], a self-hosted recipe manager and meal planner with a FastAPI backend. Mealie ships as a single container, publishes versioned images, and serves a live OpenAPI 3.1 document from `/openapi.json`. It's standing in for whatever service your project consumes; the interesting part is the derivation, not the recipes.
+The worked example uses [Mealie][mealie], a self-hosted recipe manager and meal planner with a FastAPI backend. Mealie ships as a single container, publishes versioned images, and serves a live OpenAPI 3.1 document from `/openapi.json`. It stands in for whatever service your project consumes; the interesting part is the derivation, not the recipes.
 
 The test we're building does the following, every time the suite runs:
 
@@ -227,9 +225,9 @@ func TestMealieClientIsUpToDate(t *testing.T) {
 }
 ```
 
-One design decision is invisible in that listing but important: this test never imports the generated client. If a bad schema ever produces a client that doesn't compile, a test that imported it couldn't build either, and the one tool capable of regenerating a working client would be broken by the very problem it exists to fix. Keeping the codegen test free of dependencies on its own output preserves the repair path.
+This test never imports the generated client. If a bad schema produces a client that doesn't compile, a test that imported it couldn't build either. The codegen test must remain independent of its output so it can still repair it.
 
-### Capture the API Description
+### Fetch and Stabilise the Schema
 
 The container setup is ordinary `os/exec` plumbing around Docker, so I'll show the parts that carry decisions and describe the rest. The image is pinned by both tag and digest, which makes the test's answer to "which version of the API are we generating against?" exact:
 
@@ -258,7 +256,7 @@ func startMealie(t *testing.T) (baseURL string) {
 
 Publishing onto a Docker-assigned ephemeral port means two copies of the test can run at once without fighting over a port number, and `t.Cleanup` removes the container even when the test fails. Readiness is a polling loop against `GET /api/app/about`, which conveniently also reports the running application's version, so the test log records which release actually answered.
 
-Fetching `/openapi.json` is a plain HTTP GET. Vendoring the response verbatim doesn't work, though, and the reasons are worth separating carefully because they're two different problems that are easy to blur together.
+Fetching `/openapi.json` is a plain HTTP GET. Vendoring the response verbatim doesn't work, for two separate reasons.
 
 The first problem is a generator capability gap. `ogen` v1.24.0 can't generate code for a handful of OpenAPI features that Mealie's document happens to use, most notably object-valued `default` values (23 of them). That's handled entirely in `ogen`'s own config file, without touching the JSON:
 
@@ -316,35 +314,35 @@ Two details here. Invoking `ogen` through `go run` against a `tool` directive in
 codegen.AssertFileTreeMatches(t, generatedDir, "client")
 ```
 
-I'd like to say the example worked first try, but the second run of the test failed, and the failure is a better advertisement for the pattern than a clean run would have been. Mealie's document attaches `default` as a sibling of `$ref` in 52 places, and one referenced enum (`PlanEntryType`) is given *conflicting* defaults by different parents: `"breakfast"` in three places, `"dinner"` in one. `ogen` resolves that conflict in whatever order it happens to walk a map, so `oas_defaults_gen.go` genuinely flip-flopped between `PlanEntryType("dinner")` and `PlanEntryType("breakfast")` on consecutive runs. The test reported the file as drifted, overwrote it, and failed, which is exactly what it's supposed to do when generation isn't deterministic; it just found the nondeterminism in the toolchain rather than in a colleague's manual edit. The fix went into the normalisation step: drop every `default` that sits beside a `$ref`. Those siblings are legal in OpenAPI 3.1, but when four parents disagree about a referenced schema's default there is no single value that can be preserved deterministically, so for this generator those defaults carry no information worth vendoring. After that, back-to-back runs against fresh containers pass.
+The second run of the test exposed another determinism problem. Mealie's document attaches `default` as a sibling of `$ref` in 52 places, and one referenced enum (`PlanEntryType`) is given *conflicting* defaults by different parents: `"breakfast"` in three places, `"dinner"` in one. `ogen` resolves that conflict in whatever order it happens to walk a map, so `oas_defaults_gen.go` genuinely flip-flopped between `PlanEntryType("dinner")` and `PlanEntryType("breakfast")` on consecutive runs.
 
-### Review a Version Bump
+The test reported the file as drifted, overwrote it, and failed. The fix went into the normalisation step: drop every `default` that sits beside a `$ref`. Those siblings are legal in OpenAPI 3.1, but when four parents disagree about a referenced schema's default there is no single value that can be preserved deterministically, so for this generator those defaults carry no information worth vendoring. After that, back-to-back runs against fresh containers pass.
 
-The point of all this machinery is the developer experience when something real changes, so let's walk through the intended loop. A new Mealie release comes out. You update `pinnedImage` to the new tag and digest, and run the test. It fails, reporting `schema/openapi.json` as out of date and updated in place and each client file whose generated contents changed as overwritten, with every message ending in the same instruction: inspect the diff, commit it, and rerun this test.
+### What a Version Bump Looks Like
 
-Your working tree now contains the updated schema and the regenerated client. `git diff` on the schema shows the new endpoints and changed models in OpenAPI terms; the client diff shows the same change as Go. You read both, commit them alongside the one-line version bump, rerun the test, and it passes. The entire cost of tracking a new upstream release is: change one constant, run one test, review one diff.
+When a new Mealie release comes out, you update `pinnedImage` to the new tag and digest and run the test. It fails, reporting `schema/openapi.json` as out of date and updated in place and each changed client file as overwritten. Every message tells you to inspect the diff, commit it, and rerun the test.
+
+Your working tree contains the updated schema and regenerated client. `git diff` on the schema shows the new endpoints and changed models in OpenAPI terms; the client diff shows the same change as Go. You read both, commit them alongside the version bump, and rerun the test.
 
 The same loop catches tampering. While testing this example I appended a comment to `oas_client_gen.go` and deleted `oas_validators_gen.go` outright; the next run overwrote the patched file, recreated the deleted one, and failed with a message pointing at each. A manual edit to generated code can still be *made*, but it can't quietly survive.
 
 For scale: against Mealie v3.23.1 the vendored schema is a 31,276-line JSON document (178 paths, 246 component schemas) and the generated client is 20 files totalling a little over 216,000 lines. The full test takes about 10–13 seconds on my machine, nearly all of it waiting for the container to boot.
 
-## Other Places I Have Used This Pattern
+## Other Uses
 
-Nothing about the pattern is specific to OpenAPI or to Docker; any deterministic derivation from an authoritative source can sit behind the same pair of helpers. A few from my own projects, briefly.
+Nothing about the pattern is specific to OpenAPI or Docker. A few examples from my own projects show the range.
 
 **Database migrations to ORM models.** On a work project (a Python application I can't show here), the test suite creates a throwaway PostgreSQL database, applies every migration to it, then reflects selected schemas and generates typed SQLAlchemy models, with each generated module passed through an ensure-up-to-date helper. Migrations stay the single source of truth for the database's shape, while the rest of the application gets an ORM's autocomplete and type checking. It's worth acknowledging that this is the reverse of what many frameworks do: Django and friends treat the models as authoritative and generate migrations from them, which is a perfectly good trade when the framework owns the database. Reflection-based generation earns its keep when the migrations, not the models, are the thing you need to trust.
 
 **Unityped syntax trees to typed AST wrappers.** In [WIT-LSP][wit-lsp], my language server for WIT (the interface-definition language used by the WebAssembly component model), the parser produces a loosely typed Tree-sitter syntax tree, and a generator derives strongly typed Rust wrappers (typed nodes, accessor methods, the lot) from Tree-sitter's node metadata. The [`ast_is_up_to_date` test][wit-lsp-ast] regenerates the wrappers, formats them, and reconciles the checked-in file. The idea of pairing a unityped concrete syntax tree with a generated, strongly typed AST layer comes from Matklad's [Introducing Ungrammar][ungrammar], which is worth reading if you work on language tooling.
 
-**Source declarations to explicit registries.** WIT-LSP also scans its own Rust source for the variants of a `Diagnostic` enum and [generates][wit-lsp-diag] an `all_diagnostics()` function listing every one. Adding a diagnostic is just adding an enum variant; the registry can't be forgotten because a test regenerates it from the enum itself.
-
-**Registries to reference documentation.** That same diagnostic registry carries each diagnostic's code, severity, and a Markdown description; a further derivation serialises the metadata to a checked-in JSON file, and the docs build renders it into an HTML error-code index. Source declarations feed a registry, the registry feeds structured metadata, and the metadata feeds published documentation, with a freshness test at each hop so no layer can silently fall behind the one before it.
+**Source declarations to reference documentation.** WIT-LSP scans its Rust source for the variants of a `Diagnostic` enum and [generates][wit-lsp-diag] an `all_diagnostics()` function listing every one. The registry carries each diagnostic's code, severity, and Markdown description; its metadata is serialised to a checked-in JSON file, and the docs build renders it into an HTML error-code index. Adding a diagnostic means adding an enum variant; freshness tests at each hop keep the registry and documentation aligned with the source.
 
 ## Costs and Failure Modes
 
 The pattern isn't free, and the failures divide by timescale: some break the loop the moment you hit them, while others tax the project so gradually that nobody notices until the tax is large.
 
-### Failures That Break the Loop Immediately
+### Immediate Failures
 
 **Non-deterministic generation.** The whole scheme rests on byte-for-byte comparison, so any instability in the output turns the freshness test into a machine that rewrites files at random. The Mealie example hit this twice before it settled: once from timestamps baked into the schema, once from the generator resolving conflicting defaults in map-iteration order. Unstable iteration, embedded timestamps, absolute paths, and locale-dependent formatting are the usual suspects. The fix is always the same: find the source of instability and normalise it away in a deterministic step, or fix the generator.
 
@@ -352,27 +350,23 @@ The pattern isn't free, and the failures divide by timescale: some break the loo
 
 **Dependency cycles.** If the codegen test depends, even transitively, on the code it generates, then broken generated output can stop the test from compiling, and the repair path is wedged shut. This is why `TestMealieClientIsUpToDate` never imports the client it maintains. It's an easy rule to state and a surprisingly easy one to violate by accident, because the generated package is usually the most convenient one to reach for.
 
-### Costs That Accumulate
+### Long-term Costs
 
-The slower failures are behavioural, and they're the ones with the larger long-term impact.
+A test that boots a container, provisions a database, or touches the network changes the cost of the test suite. Ten seconds sounds cheap until it's one of a dozen such tests and a suite that used to run in two seconds takes three minutes. Developers run slow suites less often or move the slow tests into a suite that runs less often, and the feedback loop gets longer. The `testing.Short()` guard in the worked example is a small concession; these tests still belong in CI on every change and on developer machines when relevant.
 
-A test that boots a container, or provisions a database, or touches the network, is a different animal to the rest of your unit tests. Ten seconds sounds cheap until it's one of a dozen such tests and the suite that used to run in two seconds now takes three minutes. Developers respond to slow suites in predictable ways: they run tests less often, or they carve the slow ones into a separate suite that runs less often, and either way the feedback loop the pattern depends on gets longer. The `testing.Short()` guard in the worked example is a small concession to this; the honest answer is that these tests belong in CI on every change and on developer machines when relevant, and keeping that arrangement healthy takes ongoing attention.
+The generated code has a slower cost too. A 216,000-line client bloats clones and history, and every regeneration produces diffs that no human will read line by line. Reviewers adapt by skimming, which makes it easier for an important change to slip through. Vendoring the schema gives reviewers a smaller contract-level diff to focus on, but the repository cost remains. No single regeneration makes the project obviously worse, so the effect can take time to notice.
 
-The other slow cost is the generated code itself. A 216,000-line client is not a neutral thing to keep in a repository. It bloats clones and history forever, and every regeneration produces diffs that no human will genuinely read line by line. Reviewers adapt by skimming, and a culture of skimming large diffs is exactly the environment where an important change slips through. The worked example softens this by vendoring the schema too, so review can focus on the small contract-level diff and treat the client diff as its mechanical consequence, but the repository cost remains. These are frog-in-the-pot problems: no single regeneration makes anything obviously worse, so the cost only becomes visible in hindsight.
+Generated trees need an unambiguous ownership boundary, because the reconciler deletes what it doesn't recognise. Generated files should announce themselves with a `// Code generated ... DO NOT EDIT.` header and are not a customisation seam. Necessary changes belong in the authoritative source, the generator, or an explicit deterministic post-processing stage like the normalisation step above. If every consumer can regenerate the output cheaply and reproducibly, build-time generation may be simpler, at the price of the navigation, documentation, and reviewability that committed code provides.
 
-A few operational rules follow from the same concerns. Generated trees need an unambiguous ownership boundary, because the reconciler deletes what it doesn't recognise. The other two rules are answers to the same question: where is a necessary change allowed to go? Never into the generated files themselves, which should announce themselves loudly (a `// Code generated ... DO NOT EDIT.` header at minimum) and are not a customisation seam; a change belongs in the authoritative source, in the generator, or in an explicit deterministic post-processing stage like the normalisation step above. And sometimes the answer is that the output shouldn't be checked in at all: if every consumer can regenerate it cheaply and reproducibly, build-time generation avoids the review load and repository growth entirely, at the price of the navigation, documentation, and reviewability that committed code provides.
+## When It Fits
 
-## When I Reach for It
-
-Rather than a checklist, here's the shape of the situation that makes me reach for this pattern.
-
-The clearest trigger is noticing that a project has acquired a CLI incantation somebody must remember to run. Unless the project will never evolve, that instruction is a promise waiting to be broken, and moving the derivation into a test converts it from a memory problem into an ordinary red-test problem, the kind every developer already knows how to respond to.
+The clearest trigger is noticing that a project has acquired a CLI incantation somebody must remember to run. Unless the project will never evolve, that instruction is easy to miss. Putting the derivation in a test gives the project an executable check instead.
 
 The second half of the judgement is about the generation itself, because the test pattern only makes generated code *maintainable*, not worthwhile. Code generation brings real magic into a project: a build step people have to understand, large diffs, permanent history growth. It earns those costs when the derived interface is substantially better than what you'd write against otherwise. A typed client instead of hand-rolled HTTP calls, typed AST nodes instead of stringly-typed tree access, ORM models that match the real database, or the removal of genuinely large amounts of boilerplate. If the generated code is only a mild convenience, the honest move is to not generate it, and then there's nothing for the test to keep fresh.
 
-None of this means you should go hunting for places to introduce code generation this week. It's a tool-belt pattern: cheap to remember, and you'll recognise the project that needs it when you're standing in it.
+None of this means you should go hunting for places to introduce code generation this week. It's a tool-belt pattern to recognise when a useful derivation starts depending on human memory.
 
-Next time you catch yourself writing "after changing X, remember to run Y" in a README, consider giving that sentence to the test suite instead. The helpers involved are about a hundred lines, and the idea has solid prior art in Matklad's self-modifying-code post. You still pay for the container boots and the oversized diffs, but the generated code stays exactly what its source says it should be, and nobody has to remember anything.
+Next time you catch yourself writing "after changing X, remember to run Y" in a README, that is a reasonable point to consider this pattern. It won't remove the cost of generation, but it can remove one fragile instruction from the project.
 
 [self-modifying-code]: https://matklad.github.io/2022/03/26/self-modifying-code.html
 [ungrammar]: https://rust-analyzer.github.io/blog/2020/10/24/introducing-ungrammar.html

--- a/content/posts/run-your-code-generator-as-a-test.md
+++ b/content/posts/run-your-code-generator-as-a-test.md
@@ -1,0 +1,383 @@
+---
+title: Run Your Code Generator as a Test
+date: '2026-08-23T18:00:00+08:00'
+draft: true
+description: Generated code can give a project a much nicer interface, but it also introduces another maintenance step. This article shows the test pattern I use to keep generated files aligned with their source, catch manual edits, and leave every change available for review.
+tags:
+- Go
+- Testing
+- Code Generation
+- OpenAPI
+---
+
+At some point in a project's life, somebody runs a code generator. Maybe they point a client generator at an OpenAPI document, or feed a `.proto` file to `protoc`, or write a small script that turns a config file into a lookup table. The output is genuinely useful, so it gets committed, and the project's interfaces improve overnight. Then, being diligent, the author adds a line to the README: *"After changing the schema, re-run `make generate` and commit the result."*
+
+That sentence is where the trouble starts. The project now contains two representations of the same information, an authoritative one and a derived one, and the only thing keeping them consistent is a human remembering to run a command.
+
+I've used a pattern for years that removes the remembering: run the generator from the test suite, compare its output against what's checked in, repair any difference, and fail the test so the change still gets reviewed. It's a small amount of code, it works with any deterministic generator, and once it's in place the derived code simply can't drift without CI telling you about it. This article walks through the two helpers that make it work, a complete worked example that generates a Go client from a running web application, and the costs you accept by adopting it.
+
+## The Command Somebody Has to Remember
+
+A one-off generation is fine on the day it happens. The generated code matches its source because both were touched in the same sitting, and everybody involved still remembers how the pieces fit together. The problem is that projects evolve, and the moment either side can change, the derivation can rot in two different directions.
+
+The first direction is the obvious one: the authoritative input changes and nobody re-runs the generator. The API grows an endpoint, the schema gains a column, the config file gets a new entry, and the generated code keeps describing the old world. Nothing fails at the time. The mismatch surfaces weeks later as a runtime error, or as a confused developer wondering why the field they can see in the schema doesn't exist on the generated type.
+
+The second direction is sneakier. Somebody needs a small change, notices it would be quickest to make it in the generated file, and patches it directly. The patch works, it gets committed, and it quietly becomes load-bearing. Months later somebody else re-runs the generator for an unrelated reason and the patch evaporates, usually without anyone noticing until whatever depended on it breaks.
+
+Both failures have the same root cause. Re-running the generator is a task that is almost always redundant; 99% of the time the output wouldn't change, so there's no feedback loop teaching anyone to do it. Humans are bad at remembering rarely-needed chores, and a README can document the command but can't make anyone run it. If keeping two representations consistent matters, the check needs to be executable, and the natural place for an executable check is the test suite. CI already runs it, and every developer already knows what a red test means.
+
+## Run the Generator From a Test
+
+The idea isn't mine. Matklad's [Self Modifying Code][self-modifying-code] describes a test that reads its own source file, derives some generated text from another region of the code, splices it between a pair of markers, writes the file back if anything changed, and then fails so the developer commits the update. The generator stays a simple string-manipulating function, consumers see ordinary source code with normal navigation and debugging, and freshness is enforced every time the tests run.
+
+Matklad's version rewrites a region inside one file. Most of the generators I work with produce whole files, or whole directory trees, so I've generalised the same move into two helpers: one that reconciles a single file, and one that reconciles a directory the generator owns outright. The examples here are Go, but there's nothing Go-specific about the idea; I've used the same helpers in Python and Rust projects.
+
+### `EnsureFileContents()`
+
+Here's the single-file helper in full.
+
+```go
+// EnsureFileContents makes sure the file at path contains exactly contents.
+//
+// If the file already matches, EnsureFileContents returns without touching
+// anything. Otherwise it creates any missing parent directories, writes
+// contents to path, and fails the test so the resulting change has to be
+// inspected, committed, and the test rerun before it can pass again.
+func EnsureFileContents(t *testing.T, path string, contents []byte) {
+	t.Helper()
+
+	if existing, err := os.ReadFile(path); err == nil && bytes.Equal(existing, contents) {
+		return
+	} else if err != nil && !os.IsNotExist(err) {
+		t.Fatalf("unable to read %s: %v", path, err)
+	}
+
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("unable to create directory for %s: %v", path, err)
+	}
+	if err := os.WriteFile(path, contents, 0o644); err != nil {
+		t.Fatalf("unable to write %s: %v", path, err)
+	}
+
+	t.Errorf("%s was out of date and has been updated in place; inspect the diff, commit it, and rerun this test", path)
+}
+```
+
+A test that uses it derives the expected output however it likes (running a template, shelling out to a CLI, reflecting over some types) and then makes one call:
+
+```go
+func TestLookupTableIsUpToDate(t *testing.T) {
+	generated := generateLookupTable()
+	EnsureFileContents(t, "lookup_table.go", generated)
+}
+```
+
+The behaviour on drift looks strange the first time you see it: the helper *fixes* the file and then fails anyway. Why not just fix it and pass, or fail without touching anything?
+
+Because each half of that behaviour serves a different audience. Writing the file means a developer who runs the test locally is left with the correct output sitting in their working tree, as a concrete diff they can read in their usual tools, rather than a wall of "expected X, got Y" output and a chore still ahead of them. Failing the test means CI can never go green on a commit whose generated code didn't match its source, because CI's rewritten file is thrown away with the build machine. The failure message tells the developer exactly what happened and what to do next: inspect the diff, commit it, rerun. On the second run the file already matches and the test passes. Every regeneration therefore passes through a human and through code review, exactly like a handwritten change would.
+
+### `AssertFileTreeMatches()`
+
+Generators like [`ogen`][ogen] or `sqlc` emit a directory full of files, and a single-file comparison isn't enough: files can change, appear, or stop being generated at all. The tree-level helper reconciles a whole directory against the freshly generated output.
+
+```go
+// AssertFileTreeMatches reconciles targetDir so it contains exactly the
+// files found under expectedDir.
+//
+// Changed or missing files are written into targetDir. Files that exist
+// under targetDir but have no counterpart under expectedDir are deleted.
+// targetDir is therefore treated as wholly owned by the generator: a
+// handwritten file left in that directory will be removed the next time
+// this runs.
+//
+// As with EnsureFileContents, any repair still fails the test so the
+// resulting diff gets reviewed before it is trusted.
+func AssertFileTreeMatches(t *testing.T, expectedDir, targetDir string) {
+	t.Helper()
+
+	expected := readTree(t, expectedDir)
+	actual := readTree(t, targetDir)
+
+	for relPath, contents := range expected {
+		targetPath := filepath.Join(targetDir, relPath)
+		previous, existed := actual[relPath]
+		if existed && bytes.Equal(previous, contents) {
+			continue
+		}
+
+		if err := os.MkdirAll(filepath.Dir(targetPath), 0o755); err != nil {
+			t.Fatalf("unable to create directory for %s: %v", targetPath, err)
+		}
+		if err := os.WriteFile(targetPath, contents, 0o644); err != nil {
+			t.Fatalf("unable to write %s: %v", targetPath, err)
+		}
+
+		if existed {
+			t.Errorf("%s had drifted from the generated output and has been overwritten; inspect the diff, commit it, and rerun this test", targetPath)
+		} else {
+			t.Errorf("%s was missing from %s and has been created; inspect the diff, commit it, and rerun this test", targetPath, targetDir)
+		}
+	}
+
+	for relPath := range actual {
+		if _, stillExpected := expected[relPath]; stillExpected {
+			continue
+		}
+
+		targetPath := filepath.Join(targetDir, relPath)
+		if err := os.Remove(targetPath); err != nil {
+			t.Fatalf("unable to remove stale generated file %s: %v", targetPath, err)
+		}
+		t.Errorf("%s is no longer part of the generated output and has been deleted; inspect the diff, commit it, and rerun this test", targetPath)
+	}
+
+	pruneEmptyDirs(targetDir)
+}
+```
+
+{{% expand "The file-walking helpers" %}}
+
+```go
+// readTree walks dir and returns its file contents keyed by path relative to
+// dir. A missing dir is treated as an empty tree so the first run of
+// AssertFileTreeMatches against a not-yet-created target directory works.
+func readTree(t *testing.T, dir string) map[string][]byte {
+	t.Helper()
+
+	files := make(map[string][]byte)
+	err := filepath.WalkDir(dir, func(path string, entry fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if entry.IsDir() {
+			return nil
+		}
+		rel, err := filepath.Rel(dir, path)
+		if err != nil {
+			return err
+		}
+		contents, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		files[rel] = contents
+		return nil
+	})
+	if err != nil && !os.IsNotExist(err) {
+		t.Fatalf("unable to walk %s: %v", dir, err)
+	}
+	return files
+}
+
+// pruneEmptyDirs removes directories left empty by deleted files, so a
+// generator that stops emitting a subdirectory does not leave it behind.
+func pruneEmptyDirs(dir string) {
+	var dirs []string
+	_ = filepath.WalkDir(dir, func(path string, entry fs.DirEntry, err error) error {
+		if err != nil || !entry.IsDir() || path == dir {
+			return nil
+		}
+		dirs = append(dirs, path)
+		return nil
+	})
+	// Remove deepest directories first so nested empty parents collapse too.
+	for i := len(dirs) - 1; i >= 0; i-- {
+		_ = os.Remove(dirs[i]) // no-op unless the directory is now empty
+	}
+}
+```
+
+{{% /expand %}}
+
+The deletion pass is what makes this helper genuinely different from calling `EnsureFileContents()` in a loop, and it's also where the sharpest edge lives. Because stale files get removed, the target directory has to be *wholly owned* by the generator. A handwritten file dropped into that directory will survive exactly until the next test run. That's a boundary worth establishing deliberately: generated output goes in its own directory, handwritten code lives elsewhere, and the directory's ownership is obvious from its name or a README inside it.
+
+With both helpers in hand, the overall contract is worth spelling out once. The authoritative input (the schema, the migrations, the grammar) remains the only place where intentional changes happen. The test regenerates the derived code exactly and compares it byte-for-byte, which catches both drift directions from earlier: stale output when the source changed, and manual edits to the output itself. And because the output is checked in rather than produced at build time, everyone downstream still gets the good parts of committed code: jump-to-definition, autocomplete, docs rendered from the source, diffs that show up in review, and no requirement that every consumer has the generator toolchain installed.
+
+## Generate a Client From a Running API
+
+To show the whole pattern working end to end, I want a generator that somebody would actually use, against a source of truth that actually changes. Generating an API client from a real application's OpenAPI document fits both requirements, so the worked example uses [Mealie][mealie], a self-hosted recipe manager and meal planner with a FastAPI backend. Mealie ships as a single container, publishes versioned images, and serves a live OpenAPI 3.1 document from `/openapi.json`. It's standing in for whatever service your project consumes; the interesting part is the derivation, not the recipes.
+
+The test we're building does the following, every time the suite runs:
+
+1. start the pinned Mealie release in Docker and wait for it to come up;
+2. fetch its OpenAPI document and normalise it into a stable form;
+3. reconcile the vendored copy of the schema with `EnsureFileContents()`;
+4. run a pinned version of `ogen` over the vendored schema, into a temporary directory; and
+5. reconcile the checked-in client tree with `AssertFileTreeMatches()`.
+
+Here's the test itself, which is short enough to read in one go:
+
+```go
+func TestMealieClientIsUpToDate(t *testing.T) {
+	if testing.Short() {
+		t.Skip("starts a Docker container; skipped in -short mode")
+	}
+
+	baseURL := startMealie(t)
+
+	raw := fetchOpenAPI(t, baseURL)
+	normalised, stats := normaliseOpenAPI(t, raw)
+	t.Logf("normalisation: %s", stats)
+
+	schemaPath := filepath.Join("schema", "openapi.json")
+	codegen.EnsureFileContents(t, schemaPath, normalised)
+
+	generatedDir := runOgen(t, schemaPath)
+	codegen.AssertFileTreeMatches(t, generatedDir, "client")
+}
+```
+
+One design decision is invisible in that listing but important: this test never imports the generated client. If a bad schema ever produces a client that doesn't compile, a test that imported it couldn't build either, and the one tool capable of regenerating a working client would be broken by the very problem it exists to fix. Keeping the codegen test free of dependencies on its own output preserves the repair path.
+
+### Capture the API Description
+
+The container setup is ordinary `os/exec` plumbing around Docker, so I'll show the parts that carry decisions and describe the rest. The image is pinned by both tag and digest, which makes the test's answer to "which version of the API are we generating against?" exact:
+
+```go
+// pinnedImage is the exact Mealie release under test, pinned by tag and
+// digest so the worked example always exercises the same server.
+const pinnedImage = "ghcr.io/mealie-recipes/mealie:v3.23.1@sha256:5fc5cebedddb3952c1ee78f20faf42ab7e49986813fd314745aa97978a4a13eb"
+
+func startMealie(t *testing.T) (baseURL string) {
+	t.Helper()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	runCmd := exec.CommandContext(ctx, "docker", "run",
+		"--detach",
+		"--publish", "127.0.0.1::9000", // let docker pick a free host port
+		"--rm",
+		pinnedImage,
+	)
+	// ... capture the container ID, register a t.Cleanup() that force-removes
+	// the container, ask `docker port` which ephemeral host port was bound,
+	// and poll GET /api/app/about until Mealie answers (60s deadline).
+}
+```
+
+Publishing onto a Docker-assigned ephemeral port means two copies of the test can run at once without fighting over a port number, and `t.Cleanup` removes the container even when the test fails. Readiness is a polling loop against `GET /api/app/about`, which conveniently also reports the running application's version, so the test log records which release actually answered.
+
+Fetching `/openapi.json` is a plain HTTP GET. Vendoring the response verbatim doesn't work, though, and the reasons are worth separating carefully because they're two different problems that are easy to blur together.
+
+The first problem is a generator capability gap. `ogen` v1.24.0 can't generate code for a handful of OpenAPI features that Mealie's document happens to use, most notably object-valued `default` values (23 of them). That's handled entirely in `ogen`'s own config file, without touching the JSON:
+
+```yaml
+# ogen.yml
+generator:
+  # ogen v1.24.0 rejects three shapes present in Mealie v3.23.1's OpenAPI
+  # document: object-valued "default" values, a couple of complex "anyOf"
+  # schemas, and one pair of sum-type variants that share a generated name.
+  # Naming them here (rather than "all") means a future ogen upgrade that
+  # implements one of these will start failing loudly instead of silently
+  # widening what gets skipped.
+  ignore_not_implemented:
+    - "object defaults"
+    - "complex anyOf"
+    - "sum types with same names"
+```
+
+The second problem is determinism, and it lives in the document itself. Two of Mealie's schema properties embed a `default` that FastAPI computed at the moment the server process built its schema: the current wall-clock time, down to the microsecond. Fetch the document from two freshly started containers and you get two byte-different schemas even though nothing about the API changed. The normalisation step strips any string default shaped like an RFC 3339 timestamp, on the reasoning that a default which looks like a wall-clock instant didn't come from the schema author. It then re-encodes the whole document with Go's `encoding/json`, which sorts object keys and indents consistently, so two normalised fetches of an unchanged schema are byte-identical.
+
+With the document stable, the `EnsureFileContents()` call in the test above vendors it as `schema/openapi.json`. The vendored schema earns its place in the repository independently of the client. It's an auditable observation of what that exact release actually serves, so when a version bump changes the API, the schema diff shows *what* changed at the contract level before you ever look at generated Go.
+
+### Generate and Reconcile the Client
+
+Generation runs into a fresh temporary directory rather than over the top of the checked-in client:
+
+```go
+func runOgen(t *testing.T, schemaPath string) (generatedDir string) {
+	t.Helper()
+
+	generatedDir = t.TempDir()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, "go", "run", "github.com/ogen-go/ogen/cmd/ogen",
+		"-config", "ogen.yml",
+		"-target", generatedDir,
+		"-package", "mealie",
+		"-clean",
+		schemaPath,
+	)
+
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("ogen failed: %v\n%s", err, out)
+	}
+	return generatedDir
+}
+```
+
+Two details here. Invoking `ogen` through `go run` against a `tool` directive in `go.mod` pins the generator's version the same way any other dependency is pinned, so every machine that runs this test runs the same `ogen`. And generating into `t.TempDir()` means generation either completes as a whole or fails without side effects; a generator crash can't leave the committed client half-overwritten. Only after `ogen` succeeds does the reconciliation touch the real tree:
+
+```go
+codegen.AssertFileTreeMatches(t, generatedDir, "client")
+```
+
+I'd like to say the example worked first try, but the second run of the test failed, and the failure is a better advertisement for the pattern than a clean run would have been. Mealie's document attaches `default` as a sibling of `$ref` in 52 places, and one referenced enum (`PlanEntryType`) is given *conflicting* defaults by different parents: `"breakfast"` in three places, `"dinner"` in one. `ogen` resolves that conflict in whatever order it happens to walk a map, so `oas_defaults_gen.go` genuinely flip-flopped between `PlanEntryType("dinner")` and `PlanEntryType("breakfast")` on consecutive runs. The test reported the file as drifted, overwrote it, and failed, which is exactly what it's supposed to do when generation isn't deterministic; it just found the nondeterminism in the toolchain rather than in a colleague's manual edit. The fix went into the normalisation step: drop every `default` that sits beside a `$ref`. Those siblings are legal in OpenAPI 3.1, but when four parents disagree about a referenced schema's default there is no single value that can be preserved deterministically, so for this generator those defaults carry no information worth vendoring. After that, back-to-back runs against fresh containers pass.
+
+### Review a Version Bump
+
+The point of all this machinery is the developer experience when something real changes, so let's walk through the intended loop. A new Mealie release comes out. You update `pinnedImage` to the new tag and digest, and run the test. It fails, reporting `schema/openapi.json` as out of date and updated in place and each client file whose generated contents changed as overwritten, with every message ending in the same instruction: inspect the diff, commit it, and rerun this test.
+
+Your working tree now contains the updated schema and the regenerated client. `git diff` on the schema shows the new endpoints and changed models in OpenAPI terms; the client diff shows the same change as Go. You read both, commit them alongside the one-line version bump, rerun the test, and it passes. The entire cost of tracking a new upstream release is: change one constant, run one test, review one diff.
+
+The same loop catches tampering. While testing this example I appended a comment to `oas_client_gen.go` and deleted `oas_validators_gen.go` outright; the next run overwrote the patched file, recreated the deleted one, and failed with a message pointing at each. A manual edit to generated code can still be *made*, but it can't quietly survive.
+
+For scale: against Mealie v3.23.1 the vendored schema is a 31,276-line JSON document (178 paths, 246 component schemas) and the generated client is 20 files totalling a little over 216,000 lines. The full test takes about 10–13 seconds on my machine, nearly all of it waiting for the container to boot.
+
+## Other Places I Have Used This Pattern
+
+Nothing about the pattern is specific to OpenAPI or to Docker; any deterministic derivation from an authoritative source can sit behind the same pair of helpers. A few from my own projects, briefly.
+
+**Database migrations to ORM models.** On a work project (a Python application I can't show here), the test suite creates a throwaway PostgreSQL database, applies every migration to it, then reflects selected schemas and generates typed SQLAlchemy models, with each generated module passed through an ensure-up-to-date helper. Migrations stay the single source of truth for the database's shape, while the rest of the application gets an ORM's autocomplete and type checking. It's worth acknowledging that this is the reverse of what many frameworks do: Django and friends treat the models as authoritative and generate migrations from them, which is a perfectly good trade when the framework owns the database. Reflection-based generation earns its keep when the migrations, not the models, are the thing you need to trust.
+
+**Unityped syntax trees to typed AST wrappers.** In [WIT-LSP][wit-lsp], my language server for WIT (the interface-definition language used by the WebAssembly component model), the parser produces a loosely typed Tree-sitter syntax tree, and a generator derives strongly typed Rust wrappers (typed nodes, accessor methods, the lot) from Tree-sitter's node metadata. The [`ast_is_up_to_date` test][wit-lsp-ast] regenerates the wrappers, formats them, and reconciles the checked-in file. The idea of pairing a unityped concrete syntax tree with a generated, strongly typed AST layer comes from Matklad's [Introducing Ungrammar][ungrammar], which is worth reading if you work on language tooling.
+
+**Source declarations to explicit registries.** WIT-LSP also scans its own Rust source for the variants of a `Diagnostic` enum and [generates][wit-lsp-diag] an `all_diagnostics()` function listing every one. Adding a diagnostic is just adding an enum variant; the registry can't be forgotten because a test regenerates it from the enum itself.
+
+**Registries to reference documentation.** That same diagnostic registry carries each diagnostic's code, severity, and a Markdown description; a further derivation serialises the metadata to a checked-in JSON file, and the docs build renders it into an HTML error-code index. Source declarations feed a registry, the registry feeds structured metadata, and the metadata feeds published documentation, with a freshness test at each hop so no layer can silently fall behind the one before it.
+
+## Costs and Failure Modes
+
+The pattern isn't free, and the failures divide by timescale: some break the loop the moment you hit them, while others tax the project so gradually that nobody notices until the tax is large.
+
+### Failures That Break the Loop Immediately
+
+**Non-deterministic generation.** The whole scheme rests on byte-for-byte comparison, so any instability in the output turns the freshness test into a machine that rewrites files at random. The Mealie example hit this twice before it settled: once from timestamps baked into the schema, once from the generator resolving conflicting defaults in map-iteration order. Unstable iteration, embedded timestamps, absolute paths, and locale-dependent formatting are the usual suspects. The fix is always the same: find the source of instability and normalise it away in a deterministic step, or fix the generator.
+
+**Unpinned tools.** If two developers have different versions of the generator installed, the checked-in output ping-pongs between them and every regeneration is suspect. Pin the generator the same way you pin every other dependency; the `tool` directive in `go.mod` does this for Go, lockfiles do it elsewhere. The container digest in the worked example is the same principle applied to the upstream service.
+
+**Dependency cycles.** If the codegen test depends, even transitively, on the code it generates, then broken generated output can stop the test from compiling, and the repair path is wedged shut. This is why `TestMealieClientIsUpToDate` never imports the client it maintains. It's an easy rule to state and a surprisingly easy one to violate by accident, because the generated package is usually the most convenient one to reach for.
+
+### Costs That Accumulate
+
+The slower failures are behavioural, and they're the ones with the larger long-term impact.
+
+A test that boots a container, or provisions a database, or touches the network, is a different animal to the rest of your unit tests. Ten seconds sounds cheap until it's one of a dozen such tests and the suite that used to run in two seconds now takes three minutes. Developers respond to slow suites in predictable ways: they run tests less often, or they carve the slow ones into a separate suite that runs less often, and either way the feedback loop the pattern depends on gets longer. The `testing.Short()` guard in the worked example is a small concession to this; the honest answer is that these tests belong in CI on every change and on developer machines when relevant, and keeping that arrangement healthy takes ongoing attention.
+
+The other slow cost is the generated code itself. A 216,000-line client is not a neutral thing to keep in a repository. It bloats clones and history forever, and every regeneration produces diffs that no human will genuinely read line by line. Reviewers adapt by skimming, and a culture of skimming large diffs is exactly the environment where an important change slips through. The worked example softens this by vendoring the schema too, so review can focus on the small contract-level diff and treat the client diff as its mechanical consequence, but the repository cost remains. These are frog-in-the-pot problems: no single regeneration makes anything obviously worse, so the cost only becomes visible in hindsight.
+
+A few operational rules follow from the same concerns. Generated trees need an unambiguous ownership boundary, because the reconciler deletes what it doesn't recognise. The other two rules are answers to the same question: where is a necessary change allowed to go? Never into the generated files themselves, which should announce themselves loudly (a `// Code generated ... DO NOT EDIT.` header at minimum) and are not a customisation seam; a change belongs in the authoritative source, in the generator, or in an explicit deterministic post-processing stage like the normalisation step above. And sometimes the answer is that the output shouldn't be checked in at all: if every consumer can regenerate it cheaply and reproducibly, build-time generation avoids the review load and repository growth entirely, at the price of the navigation, documentation, and reviewability that committed code provides.
+
+## When I Reach for It
+
+Rather than a checklist, here's the shape of the situation that makes me reach for this pattern.
+
+The clearest trigger is noticing that a project has acquired a CLI incantation somebody must remember to run. Unless the project will never evolve, that instruction is a promise waiting to be broken, and moving the derivation into a test converts it from a memory problem into an ordinary red-test problem, the kind every developer already knows how to respond to.
+
+The second half of the judgement is about the generation itself, because the test pattern only makes generated code *maintainable*, not worthwhile. Code generation brings real magic into a project: a build step people have to understand, large diffs, permanent history growth. It earns those costs when the derived interface is substantially better than what you'd write against otherwise. A typed client instead of hand-rolled HTTP calls, typed AST nodes instead of stringly-typed tree access, ORM models that match the real database, or the removal of genuinely large amounts of boilerplate. If the generated code is only a mild convenience, the honest move is to not generate it, and then there's nothing for the test to keep fresh.
+
+None of this means you should go hunting for places to introduce code generation this week. It's a tool-belt pattern: cheap to remember, and you'll recognise the project that needs it when you're standing in it.
+
+Next time you catch yourself writing "after changing X, remember to run Y" in a README, consider giving that sentence to the test suite instead. The helpers involved are about a hundred lines, and the idea has solid prior art in Matklad's self-modifying-code post. You still pay for the container boots and the oversized diffs, but the generated code stays exactly what its source says it should be, and nobody has to remember anything.
+
+[self-modifying-code]: https://matklad.github.io/2022/03/26/self-modifying-code.html
+[ungrammar]: https://rust-analyzer.github.io/blog/2020/10/24/introducing-ungrammar.html
+[mealie]: https://github.com/mealie-recipes/mealie
+[ogen]: https://github.com/ogen-go/ogen
+[wit-lsp]: https://github.com/Michael-F-Bryan/wit-lsp
+[wit-lsp-ast]: https://github.com/Michael-F-Bryan/wit-lsp/blob/c90addb21d37f2bd62a9474adca1dd8f6320d437/crates/xtask/src/codegen/ast.rs#L609-L620
+[wit-lsp-diag]: https://github.com/Michael-F-Bryan/wit-lsp/blob/c90addb21d37f2bd62a9474adca1dd8f6320d437/crates/xtask/src/codegen/diagnostics.rs

--- a/content/posts/run-your-code-generator-as-a-test.md
+++ b/content/posts/run-your-code-generator-as-a-test.md
@@ -14,17 +14,17 @@ At some point in a project's life, somebody runs a code generator. Maybe they po
 
 That sentence is where the trouble starts. The project now contains two representations of the same information, an authoritative one and a derived one, and the only thing keeping them consistent is a human remembering to run a command.
 
-I've used a pattern for years: run the generator from the test suite, compare its output against what's checked in, repair any difference, and fail the test so the change still gets reviewed. It's a small amount of code and works with any deterministic generator. CI then has a way to report drift instead of relying on a README instruction.
+I've used a version of the same pattern for years. Run the generator from the test suite, compare its output with what's checked in, fix any difference in place, and then fail the test anyway so the change still gets reviewed. It's not much code, and it gives CI something concrete to complain about instead of relying on that README instruction.
 
 ## How Generated Code Drifts
 
-A one-off generation is fine on the day it happens. The generated code matches its source because both were touched in the same sitting, and everybody involved still remembers how the pieces fit together. The problem is that projects evolve, and the moment either side can change, the derivation can rot in two different directions.
+A one-off generation is usually fine on the day it happens. The generated code matches its source because both were touched in the same sitting, and everybody involved still remembers how the pieces fit together. The trouble tends to show up later, once either side can change on its own.
 
-The first direction is the obvious one: the authoritative input changes and nobody re-runs the generator. The API grows an endpoint, the schema gains a column, the config file gets a new entry, and the generated code keeps describing the old world. Nothing fails at the time. The mismatch surfaces weeks later as a runtime error, or as a confused developer wondering why the field they can see in the schema doesn't exist on the generated type.
+The obvious case is that the authoritative input changes and nobody re-runs the generator. The API grows an endpoint, the schema gains a column, the config file gets a new entry, and the generated code keeps describing the old world. Nothing fails at the time. The mismatch surfaces weeks later as a runtime error, or as a confused developer wondering why the field they can see in the schema doesn't exist on the generated type.
 
-The second direction is sneakier. Somebody needs a small change, notices it would be quickest to make it in the generated file, and patches it directly. The patch works, it gets committed, and it quietly becomes load-bearing. Months later somebody else re-runs the generator for an unrelated reason and the patch evaporates, usually without anyone noticing until whatever depended on it breaks.
+You can also get drift in the other direction. Somebody needs a small change, notices it would be quickest to make it in the generated file, and patches it directly. The patch works, it gets committed, and it quietly becomes load-bearing. Months later somebody else re-runs the generator for an unrelated reason and the patch evaporates, usually without anyone noticing until whatever depended on it breaks.
 
-Both failures have the same root cause. Re-running the generator is almost always redundant; 99% of the time the output wouldn't change, so there's no feedback loop teaching anyone to do it. Humans are bad at remembering rarely-needed chores. A README can document the command, but the test suite can run it in CI and give developers a familiar red test when the representations diverge.
+In both cases, re-running the generator is a chore that matters only occasionally. Most runs wouldn't change anything, so there's no feedback loop teaching anyone to remember it. A README can document the command, but the test suite can run it in CI and give developers a familiar red test when the representations diverge.
 
 ## Run the Generator From a Test
 
@@ -183,13 +183,13 @@ func pruneEmptyDirs(dir string) {
 
 The deletion pass distinguishes this helper from calling `EnsureFileContents()` in a loop. Because stale files get removed, the target directory has to be *wholly owned* by the generator. A handwritten file dropped into that directory will survive until the next test run. Put generated output in its own directory, with the ownership clear from its name or a README.
 
-Together, the helpers establish the contract. The authoritative input (the schema, the migrations, the grammar) is where intentional changes happen. The test regenerates the derived code and compares it byte-for-byte, so changes to either side show up as a failing test. Checked-in output still gives downstream users jump-to-definition, autocomplete, rendered documentation, reviewable diffs, and no requirement to install the generator toolchain.
+With those two helpers, intentional changes still happen in the authoritative input (the schema, the migrations, the grammar), and the test checks the derived code byte-for-byte. I still prefer to check the output in because downstream users get jump-to-definition, autocomplete, rendered documentation, and ordinary reviewable diffs without needing the generator toolchain installed.
 
 ## A Real OpenAPI Client
 
 The worked example uses [Mealie][mealie], a self-hosted recipe manager and meal planner with a FastAPI backend. Mealie ships as a single container, publishes versioned images, and serves a live OpenAPI 3.1 document from `/openapi.json`. It stands in for whatever service your project consumes; the interesting part is the derivation, not the recipes.
 
-The test we're building does the following, every time the suite runs:
+The finished test does the following every time the suite runs:
 
 1. start the pinned Mealie release in Docker and wait for it to come up;
 2. fetch its OpenAPI document and normalise it into a stable form;
@@ -197,7 +197,7 @@ The test we're building does the following, every time the suite runs:
 4. run a pinned version of `ogen` over the vendored schema, into a temporary directory; and
 5. reconcile the checked-in client tree with `AssertFileTreeMatches()`.
 
-Here's the test itself, which is short enough to read in one go:
+Getting there wasn't quite as linear as that list makes it look, particularly once the real OpenAPI document started exposing determinism problems. The test itself is short enough to read in one go:
 
 ```go
 func TestMealieClientIsUpToDate(t *testing.T) {
@@ -250,9 +250,9 @@ func startMealie(t *testing.T) (baseURL string) {
 
 Publishing onto a Docker-assigned ephemeral port means two copies of the test can run at once without fighting over a port number, and `t.Cleanup` removes the container even when the test fails. Readiness is a polling loop against `GET /api/app/about`, which conveniently also reports the running application's version, so the test log records which release actually answered.
 
-Fetching `/openapi.json` is a plain HTTP GET. Vendoring the response verbatim doesn't work, for two separate reasons.
+Fetching `/openapi.json` is a plain HTTP GET. Vendoring the response verbatim didn't work.
 
-The first problem is a generator capability gap. `ogen` v1.24.0 can't generate code for a handful of OpenAPI features that Mealie's document happens to use, most notably object-valued `default` values (23 of them). That's handled entirely in `ogen`'s own config file, without touching the JSON:
+For a start, `ogen` v1.24.0 can't generate code for a handful of OpenAPI features that Mealie's document happens to use, most notably object-valued `default` values (23 of them). I could handle those entirely in `ogen`'s own config file without touching the JSON:
 
 ```yaml
 # ogen.yml
@@ -269,7 +269,7 @@ generator:
     - "sum types with same names"
 ```
 
-The second problem is determinism, and it lives in the document itself. Two of Mealie's schema properties embed a `default` that FastAPI computed at the moment the server process built its schema: the current wall-clock time, down to the microsecond. Fetch the document from two freshly started containers and you get two byte-different schemas even though nothing about the API changed. The normalisation step strips any string default shaped like an RFC 3339 timestamp, on the reasoning that a default which looks like a wall-clock instant didn't come from the schema author. It then re-encodes the whole document with Go's `encoding/json`, which sorts object keys and indents consistently, so two normalised fetches of an unchanged schema are byte-identical.
+That got `ogen` running, but the document still wasn't stable. Two of Mealie's schema properties embed a `default` that FastAPI computed at the moment the server process built its schema: the current wall-clock time, down to the microsecond. Fetch the document from two freshly started containers and you get two byte-different schemas even though nothing about the API changed. The normalisation step strips any string default shaped like an RFC 3339 timestamp, on the reasoning that a default which looks like a wall-clock instant didn't come from the schema author. It then re-encodes the whole document with Go's `encoding/json`, which sorts object keys and indents consistently, so two normalised fetches of an unchanged schema are byte-identical.
 
 With the document stable, the `EnsureFileContents()` call in the test above vendors it as `schema/openapi.json`. The vendored schema earns its place in the repository independently of the client. It's an auditable observation of what that exact release actually serves, so when a version bump changes the API, the schema diff shows *what* changed at the contract level before you ever look at generated Go.
 
@@ -302,7 +302,7 @@ func runOgen(t *testing.T, schemaPath string) (generatedDir string) {
 }
 ```
 
-Two details here. Invoking `ogen` through `go run` against a `tool` directive in `go.mod` pins the generator's version the same way any other dependency is pinned, so every machine that runs this test runs the same `ogen`. And generating into `t.TempDir()` means generation either completes as a whole or fails without side effects; a generator crash can't leave the committed client half-overwritten. Only after `ogen` succeeds does the reconciliation touch the real tree:
+Invoking `ogen` through `go run` against a `tool` directive in `go.mod` pins the generator's version the same way as any other dependency, so every machine runs the same `ogen`. I generate into `t.TempDir()` because I don't want a failed generator leaving the committed client half-overwritten. The reconciliation only touches the real tree after `ogen` succeeds:
 
 ```go
 codegen.AssertFileTreeMatches(t, generatedDir, "client")
@@ -334,11 +334,11 @@ Nothing about the pattern is specific to OpenAPI or Docker. A few examples from 
 
 ## Costs and Failure Modes
 
-The pattern isn't free, and the failures divide by timescale: some break the loop the moment you hit them, while others tax the project so gradually that nobody notices until the tax is large.
+The pattern isn't free. Some problems break the loop immediately; others just make the project a little heavier each time you regenerate.
 
 ### Immediate Failures
 
-**Non-deterministic generation.** The whole scheme rests on byte-for-byte comparison, so any instability in the output turns the freshness test into a machine that rewrites files at random. The Mealie example hit this twice before it settled: once from timestamps baked into the schema, once from the generator resolving conflicting defaults in map-iteration order. Unstable iteration, embedded timestamps, absolute paths, and locale-dependent formatting are the usual suspects. The fix is always the same: find the source of instability and normalise it away in a deterministic step, or fix the generator.
+**Non-deterministic generation.** The whole scheme rests on byte-for-byte comparison, so any instability in the output turns the freshness test into a machine that rewrites files at random. The Mealie example hit this twice before it settled: once from timestamps baked into the schema, once from the generator resolving conflicting defaults in map-iteration order. Unstable iteration, embedded timestamps, absolute paths, and locale-dependent formatting are the usual suspects. There isn't much of a shortcut here: find the source of the instability and normalise it away, or fix the generator.
 
 **Unpinned tools.** If two developers have different versions of the generator installed, the checked-in output ping-pongs between them and every regeneration is suspect. Pin the generator the same way you pin every other dependency; the `tool` directive in `go.mod` does this for Go, lockfiles do it elsewhere. The container digest in the worked example is the same principle applied to the upstream service.
 
@@ -352,13 +352,11 @@ The generated code has a slower cost too. A 216,000-line client bloats clones an
 
 ## When It Fits
 
-The clearest trigger is noticing that a project has acquired a CLI incantation somebody must remember to run. Unless the project will never evolve, that instruction is easy to miss. Putting the derivation in a test gives the project an executable check instead.
+I normally reach for this pattern when a project has acquired a CLI incantation that somebody needs to remember to run. That sort of instruction is easy to miss, especially when it only matters once every few months. Putting the derivation in a test means I don't need to pretend the README will be enough.
 
-The second half of the judgement is about the generation itself, because the test pattern only makes generated code *maintainable*, not worthwhile. Code generation brings real magic into a project: a build step people have to understand, large diffs, permanent history growth. It earns those costs when the derived interface is substantially better than what you'd write against otherwise. A typed client instead of hand-rolled HTTP calls, typed AST nodes instead of stringly-typed tree access, ORM models that match the real database, or the removal of genuinely large amounts of boilerplate. If the generated code is only a mild convenience, the honest move is to not generate it, and then there's nothing for the test to keep fresh.
+This doesn't answer whether the generated code is worth having. Code generation brings real magic into a project: a build step people have to understand, large diffs, permanent history growth. I think it earns those costs when the derived interface is substantially better than what you'd write against otherwise: a typed client instead of hand-rolled HTTP calls, typed AST nodes instead of stringly-typed tree access, ORM models that match the real database, or the removal of genuinely large amounts of boilerplate. If the result is only a mild convenience, I'd rather not generate it in the first place.
 
-None of this means you should go hunting for places to introduce code generation this week. It's a tool-belt pattern to recognise when a useful derivation starts depending on human memory.
-
-Next time you catch yourself writing *"after changing X, remember to run Y"* in a README, that is a reasonable point to consider this pattern. It won't remove the cost of generation, but it can remove one fragile instruction from the project.
+I wouldn't go hunting for places to introduce code generation just to use this pattern. But when I catch myself writing *"after changing X, remember to run Y"* in a README, I now stop and see whether a test can own that chore instead. It doesn't make generation free. It does mean one less thing has to live in somebody's head.
 
 [self-modifying-code]: https://matklad.github.io/2022/03/26/self-modifying-code.html
 [ungrammar]: https://rust-analyzer.github.io/blog/2020/10/24/introducing-ungrammar.html

--- a/content/posts/run-your-code-generator-as-a-test.md
+++ b/content/posts/run-your-code-generator-as-a-test.md
@@ -131,11 +131,7 @@ func AssertFileTreeMatches(t *testing.T, expectedDir, targetDir string) {
 
 	pruneEmptyDirs(targetDir)
 }
-```
 
-{{% expand "The file-walking helpers" %}}
-
-```go
 // readTree walks dir and returns its file contents keyed by path relative to
 // dir. A missing dir is treated as an empty tree so the first run of
 // AssertFileTreeMatches against a not-yet-created target directory works.
@@ -184,8 +180,6 @@ func pruneEmptyDirs(dir string) {
 	}
 }
 ```
-
-{{% /expand %}}
 
 The deletion pass distinguishes this helper from calling `EnsureFileContents()` in a loop. Because stale files get removed, the target directory has to be *wholly owned* by the generator. A handwritten file dropped into that directory will survive until the next test run. Put generated output in its own directory, with the ownership clear from its name or a README.
 
@@ -356,8 +350,6 @@ A test that boots a container, provisions a database, or touches the network cha
 
 The generated code has a slower cost too. A 216,000-line client bloats clones and history, and every regeneration produces diffs that no human will read line by line. Reviewers adapt by skimming, which makes it easier for an important change to slip through. Vendoring the schema gives reviewers a smaller contract-level diff to focus on, but the repository cost remains. No single regeneration makes the project obviously worse, so the effect can take time to notice.
 
-Generated trees need an unambiguous ownership boundary, because the reconciler deletes what it doesn't recognise. Generated files should announce themselves with a `// Code generated ... DO NOT EDIT.` header and are not a customisation seam. Necessary changes belong in the authoritative source, the generator, or an explicit deterministic post-processing stage like the normalisation step above. If every consumer can regenerate the output cheaply and reproducibly, build-time generation may be simpler, at the price of the navigation, documentation, and reviewability that committed code provides.
-
 ## When It Fits
 
 The clearest trigger is noticing that a project has acquired a CLI incantation somebody must remember to run. Unless the project will never evolve, that instruction is easy to miss. Putting the derivation in a test gives the project an executable check instead.
@@ -366,7 +358,7 @@ The second half of the judgement is about the generation itself, because the tes
 
 None of this means you should go hunting for places to introduce code generation this week. It's a tool-belt pattern to recognise when a useful derivation starts depending on human memory.
 
-Next time you catch yourself writing "after changing X, remember to run Y" in a README, that is a reasonable point to consider this pattern. It won't remove the cost of generation, but it can remove one fragile instruction from the project.
+Next time you catch yourself writing *"after changing X, remember to run Y"* in a README, that is a reasonable point to consider this pattern. It won't remove the cost of generation, but it can remove one fragile instruction from the project.
 
 [self-modifying-code]: https://matklad.github.io/2022/03/26/self-modifying-code.html
 [ungrammar]: https://rust-analyzer.github.io/blog/2020/10/24/introducing-ungrammar.html


### PR DESCRIPTION
Adds a draft article about moving deterministic source generation into the test suite, so checked-in output cannot drift from its source without producing a failing, reviewable diff.

The worked example starts a pinned Mealie release, vendors its OpenAPI document, runs a pinned `ogen` into a temporary directory, and reconciles both the schema and generated client. The article then applies the same two helpers to generated ORM models, typed AST wrappers, registries, and reference documentation, before covering the runtime, review, and repository costs that determine whether generation earns its place.

The example and helper code were exercised independently against Mealie v3.23.1 and `ogen` v1.24.0. Private implementations are neither named nor reconstructed, and the post remains `draft: true` for review.
